### PR TITLE
set correct color for BOOLEAN NULL in json

### DIFF
--- a/VS2019-Dark.xml
+++ b/VS2019-Dark.xml
@@ -213,7 +213,7 @@ Note:        I don't claim any ownership of this theme. It is merely a replica o
             <WordsStyle name="NUMBER" styleID="4" fgColor="A6CEA8" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING DOUBLE QUOTE" styleID="6" fgColor="D7BA7D" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING SINGLE QUOTE" styleID="7" fgColor="808080" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="">import</WordsStyle>
-            <WordsStyle name="BOOLEAN NULL" styleID="5" fgColor="569CD6" bgColor="1E1E1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1">import</WordsStyle>
+            <WordsStyle name="BOOLEAN NULL" styleID="11" fgColor="569CD6" bgColor="1E1E1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1">import</WordsStyle>
             <WordsStyle name="OPERATOR" styleID="10" fgColor="9B9B9B" bgColor="1E1E1E" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="asp" desc="asp" ext="">


### PR DESCRIPTION
This fixes #3
new look:
![grafik](https://user-images.githubusercontent.com/6975881/162000660-ef7cc1a5-2ff8-4253-b88b-c455b581512a.png)
