### PR TITLE
Fix Cursor Next to Highlighted Bracket Pair #6

### DIFF
--- a/VS2019-Dark.xml
+++ b/VS2019-Dark.xml
@@ -1400,7 +1400,7 @@ Note:        I don't claim any ownership of this theme. It is merely a replica o
         <WidgetStyle name="Global override" styleID="0" fgColor="F1F2F3" bgColor="1E1E1E" fontName="Consolas" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Default Style" styleID="32" fgColor="F0F0F0" bgColor="1E1E1E" fontName="Consolas" fontStyle="0" fontSize="11" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="696969" bgColor="1E1E1E" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="000000" bgColor="80FF80" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FFFFFF" bgColor="00698C" fontName="" fontStyle="1" fontSize="" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="FFFFFF" bgColor="CA0000" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="0F0F0F" fgColor="DCDCDC" fontStyle="0" fontSize="" />
         <WidgetStyle name="Mark colour" styleID="0" fgColor="DCDCDC" bgColor="264F78" fontStyle="0" />


### PR DESCRIPTION
Fix #6. Make the theme look like Visual Studio's bracket highlighting and allow the cursor (light) to be seen next to a highlighted pair.

Before:

![image](https://github.com/hellon8/VS2019-Dark-Npp/assets/235748/087465d5-5da7-4ab7-9a67-5b7784fa8fc3)

After:

![image](https://github.com/hellon8/VS2019-Dark-Npp/assets/235748/21f6ea28-eb5b-44ff-a0df-3ead5e282bf9)
